### PR TITLE
Adjust spacing, clarify status message

### DIFF
--- a/macme/chat_api.rb
+++ b/macme/chat_api.rb
@@ -277,7 +277,7 @@ module MacMe
 
         response = devices.empty? ?
                      "#{username}: No devices currently registered" :
-                     "#{username}: Devices registered - #{devices.join(',')}"
+                     "#{username}: Your registered devices - #{devices.join(', ')}"
 
         user_respond(topic, response)
       end


### PR DESCRIPTION
- Add a space when joining an array of devices
- Clarify that the displayed devices are _yours_, and not all devices